### PR TITLE
Add engines key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Agenda Dashboard",
   "main": "app.js",
   "bin": "bin/agendash-standalone.js",
+  "engines": {
+    "node": ">=4.0.0",
+    "npm": ">=2.0.0"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Helps people to see when they're running too old Node version, see e.g. #20