### PR TITLE
4.0.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,11 @@
+0.4.0 / 2016-10-27
+==================
+
+  * (simison) Agenda dependency version `<1.0.0` to avoid breaking dependency.
+  * (loris) Fix #24 - Added indexes for faster queries.
+  * Fix #28 - Removed dependency on Mongo Driver.
+  * Added API tests with mocha and supertest. No frontend tests.
+
 0.3.2 / 2016-06-30
 ==================
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agendash",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Agenda Dashboard",
   "main": "app.js",
   "bin": "bin/agendash-standalone.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -631,8 +631,8 @@ superagent@^2.0.0:
     readable-stream "^2.0.5"
 
 supertest@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/supertest/-/supertest-2.0.0.tgz#060e18edae56e3d62b95c6e9c4e2a5e4e50979ff"
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/supertest/-/supertest-2.0.1.tgz#a058081d788f1515d4700d7502881e6b759e44cd"
   dependencies:
     methods "1.x"
     superagent "^2.0.0"


### PR DESCRIPTION
0.4.0 / 2016-10-27
==================

  * (simison) Agenda dependency version `<1.0.0` to avoid breaking dependency.
  * (loris) Fix #24 - Added indexes for faster queries.
  * Fix #28 - Removed dependency on Mongo Driver.
  * Added API tests with mocha and supertest. No frontend tests.